### PR TITLE
Remove comma to fit in 80 columns

### DIFF
--- a/docs/integrations/django.rst
+++ b/docs/integrations/django.rst
@@ -97,7 +97,7 @@ following config can be used::
         'handlers': {
             'sentry': {
                 'level': 'ERROR',
-                'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+                'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler'
             },
             'console': {
                 'level': 'DEBUG',


### PR DESCRIPTION
If you copy/paste the `LOGGING` configuration in Django's configuration, it will only pass pep8 tests by removing the comma. Since the choice about keeping/leaving the last comma is not consistent anyway, I guess this would not hurt.
